### PR TITLE
Multi-GPU support for constraints/regularizers

### DIFF
--- a/torchsample/constraints.py
+++ b/torchsample/constraints.py
@@ -24,12 +24,18 @@ class ConstraintModule(object):
         self.model = model
 
     def _apply(self, module, constraint):
+        if isinstance(module, th.nn.DataParallel):
+            module = module.module      #DataParallel wraps the module so unwrap before continuing
+            
         for name, module in module.named_children():
             if fnmatch(name, constraint.module_filter) and hasattr(module, 'weight'):
                 constraint(module)
                 self._apply(module, constraint)
 
     def _lagrangian_apply(self, module, constraint):
+        if isinstance(module, th.nn.DataParallel):
+            module = module.module      #DataParallel wraps the module so unwrap before continuing
+            
         for name, module in module.named_children():
             if fnmatch(name, constraint.module_filter) and hasattr(module, 'weight'):
                 self.loss += constraint(module)

--- a/torchsample/regularizers.py
+++ b/torchsample/regularizers.py
@@ -10,6 +10,8 @@ class RegularizerModule(object):
         self.loss = 0.
 
     def _apply(self, module, regularizer):
+        if isinstance(module, th.nn.DataParallel):
+            module = module.module      #DataParallel wraps the module so unwrap before continuing
         for name, module in module.named_children():
             if fnmatch(name, regularizer.module_filter) and hasattr(module, 'weight'):
                 self.loss += regularizer(module)


### PR DESCRIPTION
Fix to Constraints and Regularizers in order for them to work correctly when the module is wrapped into a DataParallel object.  Note that this fix could be applied in module_trainer.py but it's probably better to duplicate the code in constraints/regularizers in case others choose not to use module_trainer or change it to suit their needs.