### PR TITLE
Multi gpu support - part 2

### DIFF
--- a/torchsample/constraints.py
+++ b/torchsample/constraints.py
@@ -6,7 +6,6 @@ from fnmatch import fnmatch
 
 import torch as th
 
-
 class ConstraintModule(object):
 
     def __init__(self, constraints):
@@ -24,22 +23,16 @@ class ConstraintModule(object):
         self.model = model
 
     def _apply(self, module, constraint):
-        if isinstance(module, th.nn.DataParallel):
-            module = module.module      #DataParallel wraps the module so unwrap before continuing
-            
         for name, module in module.named_children():
             if fnmatch(name, constraint.module_filter) and hasattr(module, 'weight'):
                 constraint(module)
-                self._apply(module, constraint)
+            self._apply(module, constraint)
 
     def _lagrangian_apply(self, module, constraint):
-        if isinstance(module, th.nn.DataParallel):
-            module = module.module      #DataParallel wraps the module so unwrap before continuing
-            
         for name, module in module.named_children():
             if fnmatch(name, constraint.module_filter) and hasattr(module, 'weight'):
                 self.loss += constraint(module)
-                self._lagrangian_apply(module, constraint)
+            self._lagrangian_apply(module, constraint)
 
     def on_batch_end(self, batch):
         for constraint in self.batch_constraints:

--- a/torchsample/constraints.py
+++ b/torchsample/constraints.py
@@ -24,12 +24,18 @@ class ConstraintModule(object):
         self.model = model
 
     def _apply(self, module, constraint):
+        if isinstance(module, th.nn.DataParallel):
+            module = module.module      #DataParallel wraps the module so unwrap before continuing
+            
         for name, module in module.named_children():
             if fnmatch(name, constraint.module_filter) and hasattr(module, 'weight'):
                 constraint(module)
                 self._apply(module, constraint)
 
     def _lagrangian_apply(self, module, constraint):
+        if isinstance(module, th.nn.DataParallel):
+            module = module.module      #DataParallel wraps the module so unwrap before continuing
+            
         for name, module in module.named_children():
             if fnmatch(name, constraint.module_filter) and hasattr(module, 'weight'):
                 self.loss += constraint(module)

--- a/torchsample/metrics.py
+++ b/torchsample/metrics.py
@@ -40,7 +40,7 @@ class CategoricalAccuracy(Metric):
         self.total_count = 0
         self.accuracy = 0
 
-        self._name = 'acc_metric:top_'+str(top_k)
+        self._name = 'top_'+str(top_k)+':acc_metric'
 
     def reset(self):
         self.correct_count = 0

--- a/torchsample/regularizers.py
+++ b/torchsample/regularizers.py
@@ -10,12 +10,10 @@ class RegularizerModule(object):
         self.loss = 0.
 
     def _apply(self, module, regularizer):
-        if isinstance(module, th.nn.DataParallel):
-            module = module.module      #DataParallel wraps the module so unwrap before continuing
         for name, module in module.named_children():
             if fnmatch(name, regularizer.module_filter) and hasattr(module, 'weight'):
                 self.loss += regularizer(module)
-                self._apply(module, regularizer)
+            self._apply(module, regularizer)
 
     def __call__(self, model):
         self.loss = 0.

--- a/torchsample/regularizers.py
+++ b/torchsample/regularizers.py
@@ -10,6 +10,8 @@ class RegularizerModule(object):
         self.loss = 0.
 
     def _apply(self, module, regularizer):
+        if isinstance(module, th.nn.DataParallel):
+            module = module.module      #DataParallel wraps the module so unwrap before continuing
         for name, module in module.named_children():
             if fnmatch(name, regularizer.module_filter) and hasattr(module, 'weight'):
                 self.loss += regularizer(module)


### PR DESCRIPTION
This should add multi-GPU support across all functions. Warning that since we're dealing with a list of GPUs, the function signatures had to change slightly.

- I removed check for `nn.DataParallel` as there was simply an indentation error in original code that incorrectly applied Regularizers and Constraints only to the top level (though intended to be recursive).

- Not completely related but I added a way to differentiate between metrics when you want multiple topK results (e.g. top_1 and top_5) at the same time. The original naming was clobbering output in the logs.