### PR TITLE
Fix #39 metrics were not printed after each epoch (validation metrics)

### DIFF
--- a/torchsample/modules/module_trainer.py
+++ b/torchsample/modules/module_trainer.py
@@ -840,7 +840,7 @@ class ModuleTrainer(object):
         # put model back in training mode
         self.model.train()
         if self._has_metrics:
-            return total_loss / float(total_samples), {k.split('_metric')[0]:v for k,v in metric_logs.items()}
+            return total_loss / float(total_samples), metric_logs.items()
         else:
             return total_loss / float(total_samples)
 


### PR DESCRIPTION
k.split('_metric')  was done twice: after an epoch and during printing. Remove the one after each epoch.