### PR TITLE
Changes math.inf to np.inf to keep py2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ trainer.compile(loss='nll_loss',
                 optimizer='adadelta')
 
 trainer.fit(x_train, y_train, 
-            validation_data=(x_test, y_test),
+            val_data=(x_test, y_test),
             num_epoch=20, 
             batch_size=128,
             verbose=1)
@@ -122,7 +122,7 @@ train_loader = DataLoader(train_dataset, batch_size=32)
 val_dataset = TensorDataset(x_val, y_val)
 val_loader = DataLoader(val_dataset, batch_size=32)
 
-model.fit_loader(loader, val_loader=val_loader, nb_epoch=100)
+trainer.fit_loader(loader, val_loader=val_loader, num_epoch=100)
 ```
 
 ## Utility Functions

--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -15,6 +15,7 @@ import time
 from tempfile import NamedTemporaryFile
 import shutil
 import datetime
+import numpy as np
 
 from tqdm import tqdm
 

--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -14,7 +14,6 @@ import csv
 import time
 from tempfile import NamedTemporaryFile
 import shutil
-import math
 import datetime
 
 from tqdm import tqdm
@@ -281,7 +280,7 @@ class ModelCheckpoint(Callback):
             self.old_files = []
 
         # mode = 'min' only supported
-        self.best_loss = math.inf
+        self.best_loss = np.inf
         super(ModelCheckpoint, self).__init__()
 
     def save_checkpoint(self, state, is_best=False):


### PR DESCRIPTION
math.inf was breaking in the callbacks.py so I changed it to the numpy equivalent, available both in py2 and py3