### PR TITLE
A possible fix for the multiple output issue for data augmentation

### DIFF
--- a/torchsample/transforms/affine_transforms.py
+++ b/torchsample/transforms/affine_transforms.py
@@ -129,7 +129,7 @@ class Affine(object):
                                    self.tform_matrix,
                                    mode=interp[idx])
             outputs.append(input_tf)
-        return outputs if idx > 1 else outputs[0]
+        return outputs if idx >= 1 else outputs[0]
 
 
 class AffineCompose(object):
@@ -180,7 +180,7 @@ class AffineCompose(object):
                                    tform_matrix,
                                    mode=interp[idx])
             outputs.append(input_tf)
-        return outputs if idx > 1 else outputs[0]
+        return outputs if idx >= 1 else outputs[0]
 
 
 class RandomRotate(object):
@@ -321,7 +321,7 @@ class Rotate(object):
                                        mode=interp[idx],
                                        center=True)
                 outputs.append(input_tf)
-            return outputs if idx > 1 else outputs[0]
+            return outputs if idx >= 1 else outputs[0]
 
 
 class RandomTranslate(object):
@@ -488,7 +488,7 @@ class Translate(object):
                                        mode=interp[idx],
                                        center=True)
                 outputs.append(input_tf)
-            return outputs if idx > 1 else outputs[0]
+            return outputs if idx >= 1 else outputs[0]
 
 
 class RandomShear(object):
@@ -610,7 +610,7 @@ class Shear(object):
                                        mode=interp[idx],
                                        center=True)
                 outputs.append(input_tf)
-            return outputs if idx > 1 else outputs[0]
+            return outputs if idx >= 1 else outputs[0]
 
 
 class RandomZoom(object):
@@ -762,6 +762,6 @@ class Zoom(object):
                                        mode=interp[idx],
                                        center=True)
                 outputs.append(input_tf)
-            return outputs if idx > 1 else outputs[0]
+            return outputs if idx >= 1 else outputs[0]
 
 


### PR DESCRIPTION
When I call the data augmentation function on two tensors, I only get one output. The data augmentation function is defined by a class in `affine_transforms.py`.

Changing `idx > 1` to `idx >= 1` in `affine_transforms.py` fixes this issue, and returns the required two outputs corresponding to the two tensors. 