### PR TITLE
Fix dim errors in Contrast transform

### DIFF
--- a/torchsample/transforms/image_transforms.py
+++ b/torchsample/transforms/image_transforms.py
@@ -339,7 +339,7 @@ class Contrast(object):
     def __call__(self, *inputs):
         outputs = []
         for idx, _input in enumerate(inputs):
-            channel_means = _input.mean(1).mean(2)
+            channel_means = _input.mean(1, keepdim=True).mean(2, keepdim=True)
             channel_means = channel_means.expand_as(_input)
             _input = th.clamp((_input - channel_means) * self.value + channel_means,0,1)
             outputs.append(_input)


### PR DESCRIPTION
The original contrast transform doesn't set keepdim=True in torch.mean. So after performing _input.mean(1), dim 1 will be squeezed and the followed mean(2) will trigger a dim error.