### PR TITLE
Minor fixes / Make callbacks work with mode and metrics / use Conditional imports 

### DIFF
--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -30,7 +30,7 @@ def _mode_dependent_param(mode, monitor, min_delta=0):
         mode = 'auto'
 
     if mode == "auto":
-        mode == 'min' if 'acc' in monitor else 'max'
+        mode = 'max' if 'acc' in monitor else 'min'
 
     if mode == 'min':
         monitor_op = np.less

--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -341,7 +341,6 @@ class ModelCheckpoint(Callback):
         else:
             if self.verbose > 0:
                 print('\nEpoch %i: saving model to %s' % (epoch+1, file))
-            self.save_checkpoint(epoch, file)
             if self.max_save > 0:
                 if len(self.old_files) == self.max_save:
                     try:
@@ -350,6 +349,7 @@ class ModelCheckpoint(Callback):
                         pass
                     self.old_files = self.old_files[1:]
                 self.old_files.append(file)
+            self.save_checkpoint(epoch, file)
 
 
 class EarlyStopping(Callback):

--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -573,7 +573,6 @@ class ReduceLROnPlateau(Callback):
             if self.monitor_op(current_loss, self.best_loss):
                 self.best_loss = current_loss
                 self.wait = 0
-                print(self.best_loss)
             # loss didnt improve, and not in cooldown phase
             elif not (self.cooldown_counter > 0):
                 if self.wait >= self.patience:

--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -226,6 +226,13 @@ class ModelCheckpoint(Callback):
     """
     Model Checkpoint to save model weights during training
 
+    Example:
+        >>> callback = [ModelCheckpoint('./', filename='ckpt.pth.tar', save_best_only=True, max_save=1)]
+        >>> trainer.compile(...,callbacks=callbacks,...)
+        >>> trainer.fit()
+        >>> checkpoint = torch.load('ckpt.pth.tar')
+        >>> model.load_state_dict(checkpoint["state_dict"])
+
     save_checkpoint({
                 'epoch': epoch + 1,
                 'arch': args.arch,
@@ -322,7 +329,6 @@ class ModelCheckpoint(Callback):
                     self.best_loss = current_loss
                     #if self.save_weights_only:
                     #else:
-                    self.save_checkpoint(epoch, file)
                     if self.max_save > 0:
                         if len(self.old_files) == self.max_save:
                             try:
@@ -331,6 +337,7 @@ class ModelCheckpoint(Callback):
                                 pass
                             self.old_files = self.old_files[1:]
                         self.old_files.append(file)
+                    self.save_checkpoint(epoch, file)
         else:
             if self.verbose > 0:
                 print('\nEpoch %i: saving model to %s' % (epoch+1, file))

--- a/torchsample/datasets.py
+++ b/torchsample/datasets.py
@@ -279,7 +279,7 @@ def default_file_reader(x):
     if isinstance(x, str):
         if x.endswith('.npy'):
             x = npy_loader(x)
-        elif x.endsiwth('.nii.gz'):
+        elif x.endswith('.nii.gz'):
             x = nifti_loader(x)
         else:
             try:

--- a/torchsample/datasets.py
+++ b/torchsample/datasets.py
@@ -7,13 +7,22 @@ import os
 import fnmatch
 
 import numpy as np
-import pandas as pd
 import PIL.Image as Image
-import nibabel
 
 import torch as th
 
+try:
+    import pandas as pd
+except ImportError:
+    pass
+
+try:
+    import nibabel
+except ImportError:
+    pass
+
 from . import transforms
+from .utils import check_import
 
 
 class BaseDataset(object):
@@ -265,6 +274,7 @@ def default_file_reader(x):
     def npy_loader(path):
         return np.load(path)
     def nifti_loader(path):
+        check_module("nibabel")
         return nibabel.load(path).get_data()
     if isinstance(x, str):
         if x.endswith('.npy'):
@@ -375,6 +385,8 @@ class CSVDataset(BaseDataset):
             transform(s) to apply to both inputs and targets simultaneously
             during runtime loading
         """
+        check_module("pandas")
+        
         self.input_cols = _process_cols_argument(input_cols)
         self.target_cols = _process_cols_argument(target_cols)
         

--- a/torchsample/datasets.py
+++ b/torchsample/datasets.py
@@ -274,7 +274,7 @@ def default_file_reader(x):
     def npy_loader(path):
         return np.load(path)
     def nifti_loader(path):
-        check_module("nibabel")
+        check_import("nibabel")
         return nibabel.load(path).get_data()
     if isinstance(x, str):
         if x.endswith('.npy'):
@@ -385,7 +385,7 @@ class CSVDataset(BaseDataset):
             transform(s) to apply to both inputs and targets simultaneously
             during runtime loading
         """
-        check_module("pandas")
+        check_import("pandas")
         
         self.input_cols = _process_cols_argument(input_cols)
         self.target_cols = _process_cols_argument(target_cols)

--- a/torchsample/modules/_utils.py
+++ b/torchsample/modules/_utils.py
@@ -8,6 +8,7 @@ except:
     warnings.warn('inspect.signature not available... '
         'you should upgrade to Python 3.x')
 
+import torch
 import torch.nn.functional as F
 import torch.optim as optim
 
@@ -28,8 +29,11 @@ def _is_tuple_or_list(x):
 def _parse_num_inputs_and_targets_from_loader(loader):
     """ NOT IMPLEMENTED """
     #batch = next(iter(loader))
-    num_inputs = loader.dataset.num_inputs
-    num_targets = loader.dataset.num_targets
+    if isinstance(loader.dataset,torch.utils.data.dataset.Dataset):
+        num_inputs = num_targets = 1
+    else:
+        num_inputs = loader.dataset.num_inputs
+        num_targets = loader.dataset.num_targets
     return num_inputs, num_targets
 
 def _parse_num_inputs_and_targets(inputs, targets=None):

--- a/torchsample/modules/module_trainer.py
+++ b/torchsample/modules/module_trainer.py
@@ -295,6 +295,8 @@ class ModuleTrainer(object):
 
                 if self._stop_training:
                     break
+
+        #callback_container.on_train_end()
         self.model.train(mode=False)
 
     def fit_loader(self,
@@ -396,6 +398,7 @@ class ModuleTrainer(object):
 
                 if self._stop_training:
                     break
+
         self.model.train(mode=False)
 
     def predict(self,

--- a/torchsample/modules/module_trainer.py
+++ b/torchsample/modules/module_trainer.py
@@ -309,14 +309,12 @@ class ModuleTrainer(object):
         """
         self.model.train(mode=True)
         # ----------------------------------------------------------------------
-        num_inputs = loader.dataset.num_inputs
-        num_targets = loader.dataset.num_targets
+        num_inputs, num_targets = _parse_num_inputs_and_targets_from_loader(loader)
         len_inputs = len(loader.sampler) if loader.sampler else len(loader.dataset)
         batch_size = loader.batch_size
 
         if val_loader is not None:
-            num_val_inputs = val_loader.dataset.num_inputs
-            num_val_targets = val_loader.dataset.num_targets
+            num_val_inputs, num_val_targets = _parse_num_inputs_and_targets_from_loader(val_loader)
             if (num_inputs != num_val_inputs) or (num_targets != num_val_targets):
                 raise ValueError('num_inputs != num_val_inputs or num_targets != num_val_targets')
         has_val_data = val_loader is not None

--- a/torchsample/utils.py
+++ b/torchsample/utils.py
@@ -2,6 +2,7 @@
 Utility functions for th.Tensors
 """
 
+import sys
 import pickle
 import random
 import numpy as np
@@ -420,6 +421,11 @@ def load_transform(file):
         transform = pickle.load(input_file)
     return transform
     
-
+def check_import(module):
+    """
+    Checks whether the given module is imported.
+    """
+    if module not in sys.modules:
+        raise ImportError('{} module not imported. Please use "pip install {}".'.format(module,module))
 
     


### PR DESCRIPTION
Minor Fixes:
- typo in `nift_loader`, so wasn't working. 'x.endsiwth' replaced by 'x.endswith'.
- small number of changes so that `.fit_load()` works also with a `torch.utils.data.Dataset` and not only with your `TensorDataset`.
- `ModelCheckpoint`'s `max_save` was off by 1. Anoying because usually you want to keep the best model, and with the current code on master you would keep nothing! Also added an example in the docstring.

Make callbacks work with mode and metric:
- The callbacks `ModelCheckpoint`, `EarlyStopping`, `ReduceLROnPlateau` all accept a mode parameter. And it works with metrics. example : `EarlyStopping(patience=10,monitor="val_acc_metric")`

Conditional imports:
- I think there are dependencies like pandas and nibabel that are very specific that there shouldn't be required to use the package. SO i used conditional imports.

As the changes are minor I put all in the same pull request but if you want I can split.