### PR TITLE
Fix loss and accuracy logging during training

### DIFF
--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -147,12 +147,12 @@ class TQDM(Callback):
             pass
 
     def on_epoch_end(self, epoch, logs=None):
-        log_data = {key: '%.04f' % value for key, value in self.trainer.history.batch_metrics.items()}
+        log_data = {}
         for k, v in logs.items():
             if k.endswith('metric'):
                 log_data[k.split('_metric')[0]] = '%.02f' % v
             else:
-                 log_data[k] = v
+                 log_data[k] = '%.04f' % v
         self.progbar.set_postfix(log_data)
         self.progbar.update()
         self.progbar.close()
@@ -203,7 +203,7 @@ class History(Callback):
     def on_epoch_end(self, epoch, logs=None):
         #for k in self.batch_metrics:
         #    k_log = k.split('_metric')[0]
-        # self.epoch_metrics.update(self.batch_metrics)
+        self.epoch_metrics.update(self.batch_metrics)
         # TODO
         pass
 
@@ -587,6 +587,11 @@ class CSVLogger(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
+        log_data = {}
+        for k in logs:
+           k_log = k.split('_metric')[0]
+           log_data[k_log] = logs[k]
+        logs = log_data
         RK = {'num_batches', 'num_epoch'}
 
         def handle_value(k):

--- a/torchsample/modules/module_trainer.py
+++ b/torchsample/modules/module_trainer.py
@@ -291,7 +291,7 @@ class ModuleTrainer(object):
                     # TODO how to fix this?
                     # self.history.batch_metrics.update(val_epoch_logs)
 
-                callback_container.on_epoch_end(epoch_idx, self.history.epoch_metrics)
+                callback_container.on_epoch_end(epoch_idx, epoch_logs)
 
                 if self._stop_training:
                     break


### PR DESCRIPTION
During training, loss and metrics (accuracy) are not displayed or
stored at the end of each epoch. As a result, training or validation
loss cannot be retrieved after training. Furthermore, callbacks such
as CSVLogger and EarlyStopping are not functional.

Modify 'on_epoch_end' in 'History' callback, and in 'fit' method to
enable logging of loss and metrics.

Modify CSVLogger such that output file header conforms to history
logging format.

Resolves: #75, #83
See also: #60