### PR TITLE
Changed loss.data[0] to loss.data.item()

### DIFF
--- a/torchsample/modules/module_trainer.py
+++ b/torchsample/modules/module_trainer.py
@@ -277,7 +277,7 @@ class ModuleTrainer(object):
                         metrics_logs = self.metric_container(output_batch, target_batch)
                         batch_logs.update(metrics_logs)
 
-                    batch_logs['loss'] = loss.data[0]
+                    batch_logs['loss'] = loss.data.item()
                     callback_container.on_batch_end(batch_idx, batch_logs)
 
                 if has_val_data:


### PR DESCRIPTION
Originally threw error: `IndexError: invalid index of a 0-dim tensor. Use tensor.item() in Python or tensor.item<T>() in C++ to convert a 0-dim tensor to a number.`

Fixes #117 