### PR TITLE
Fix Python 3.11 import

### DIFF
--- a/torchsample/callbacks.py
+++ b/torchsample/callbacks.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from collections import OrderedDict
-from collections import Iterable
+from collections.abc import Iterable
 import warnings
 
 import os


### PR DESCRIPTION
Starting in Python 3.10, `collections.Iterable` no longer exists.  It is available as `collections.abc.Iterable`.  This was causing `import torchsample` to fail in my new Python 3.11 environment. After this update, torchsample imports successfully under Python 3.11. `collections.abc` was created starting in Python 3.3, so I expect this to work with Python>=3.3.